### PR TITLE
Initial work on setting rosout QoS

### DIFF
--- a/include/common_package/common_node.hpp
+++ b/include/common_package/common_node.hpp
@@ -23,7 +23,8 @@ namespace common_lib {
 namespace {
 
 /**
- * @brief rosout QoS to explicitly set the rosout for  Nodes subclassing CommonNode
+ * @brief rosout QoS to explicitly set the rosout for Nodes subclassing
+ * CommonNode
  *
  * See:
  * 1.

--- a/include/common_package/common_node.hpp
+++ b/include/common_package/common_node.hpp
@@ -12,7 +12,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "topic_names.hpp"
 
-
 // Message includes
 #include "interfaces/msg/heartbeat.hpp"
 #include "interfaces/msg/job_finished.hpp"

--- a/include/common_package/common_node.hpp
+++ b/include/common_package/common_node.hpp
@@ -23,7 +23,7 @@ namespace common_lib {
 namespace {
 
 /**
- * @brief rosout QoS to explicitly set the it
+ * @brief rosout QoS to explicitly set the rosout for  Nodes subclassing CommonNode
  *
  * See:
  * 1.

--- a/include/common_package/common_node.hpp
+++ b/include/common_package/common_node.hpp
@@ -20,6 +20,38 @@
 using namespace std::chrono_literals;
 
 namespace common_lib {
+
+namespace {
+
+/**
+ * @brief rosout QoS to explicitly set the it
+ *
+ * See:
+ * 1.
+ * https://docs.ros.org/en/humble/p/rclcpp/generated/classrclcpp_1_1QoS.html#_CPPv4N6rclcpp3QoSE
+ * 2.
+ * https://docs.ros.org/en/humble/p/rclcpp/generated/structrclcpp_1_1QoSInitialization.html#_CPPv4N6rclcpp17QoSInitializationE
+ * 3.
+ * https://docs.ros.org/en/humble/p/rmw/generated/structrmw__qos__profile__s.html#_CPPv417rmw_qos_profile_s
+ * 4. https://design.ros2.org/articles/qos_deadline_liveliness_lifespan.html
+ */
+const rclcpp::QoS ROSOUT_QOS{
+    rclcpp::KeepLast(1), /**< Ignored */
+    rmw_qos_profile_t{
+        rmw_qos_history_policy_t::RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        1,
+        rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
+        rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_VOLATILE,
+        rmw_time_t{0, 0},
+        rmw_time_t{1, 0},
+        rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_AUTOMATIC,
+        RMW_DURATION_INFINITE,
+        false,
+    } /**< This struct holds the default values for the QoS */
+};
+
+}  // namespace
+
 /**
  * @class CommonNode
  * @brief A class representing a common node.
@@ -32,10 +64,13 @@ class CommonNode : public rclcpp::Node {
     /**
      * @brief Constructor for creating a new CommonNode.
      * @param id Unique name of the node.
+     * @param options Optional NodeOptions
+     *
+     * @warning This constructor overrides the rosout QoS!
      */
     CommonNode(const std::string &id,
-               const rclcpp::NodeOptions &options = rclcpp::NodeOptions())
-        : Node(id, options) {
+               rclcpp::NodeOptions options = rclcpp::NodeOptions())
+        : Node(id, options.rosout_qos(ROSOUT_QOS)) {
         /// Create a publisher for the "heartbeat" topic
         heartbeat_publisher =
             this->create_publisher<interfaces::msg::Heartbeat>(

--- a/test/common_node/heartbeat_test.cpp
+++ b/test/common_node/heartbeat_test.cpp
@@ -27,7 +27,7 @@ TEST(common_package, heartbeat_rate) {
 
     rclcpp::Subscription<interfaces::msg::Heartbeat>::SharedPtr heartbeat_sub =
         test_node->create_subscription<interfaces::msg::Heartbeat>(
-            "heartbeat", 1,
+            topic_names::Heartbeat, 1,
             [&last_msg,
              test_node](interfaces::msg::Heartbeat::ConstSharedPtr msg) {
                 RCLCPP_DEBUG(test_node->get_logger(),
@@ -83,7 +83,7 @@ TEST(common_package, heartbeat_activate_deactivate) {
 
     rclcpp::Subscription<interfaces::msg::Heartbeat>::SharedPtr heartbeat_sub =
         test_node->create_subscription<interfaces::msg::Heartbeat>(
-            "heartbeat", 1,
+            topic_names::Heartbeat, 1,
             [&last_msg, test_node,
              heartbeat_node](interfaces::msg::Heartbeat::ConstSharedPtr msg) {
                 RCLCPP_DEBUG(test_node->get_logger(),

--- a/test/common_node/job_finished_test.cpp
+++ b/test/common_node/job_finished_test.cpp
@@ -46,7 +46,7 @@ TEST(common_package, job_finished_successfull) {
     rclcpp::Subscription<interfaces::msg::JobFinished>::SharedPtr
         job_finished_sub =
             test_node->create_subscription<interfaces::msg::JobFinished>(
-                "job_finished", 10,
+                topic_names::JobFinished, 10,
                 [common_node, test_node,
                  &executor](interfaces::msg::JobFinished::ConstSharedPtr msg) {
                     RCLCPP_DEBUG(test_node->get_logger(),
@@ -87,7 +87,7 @@ TEST(common_package, job_finished_error_message) {
     rclcpp::Subscription<interfaces::msg::JobFinished>::SharedPtr
         job_finished_sub =
             test_node->create_subscription<interfaces::msg::JobFinished>(
-                "job_finished", 10,
+                topic_names::JobFinished, 10,
                 [common_node, test_node,
                  &executor](interfaces::msg::JobFinished::ConstSharedPtr msg) {
                     RCLCPP_DEBUG(test_node->get_logger(),
@@ -132,7 +132,7 @@ TEST(common_package, job_finished_custom_payload) {
     rclcpp::Subscription<interfaces::msg::JobFinished>::SharedPtr
         job_finished_sub =
             test_node->create_subscription<interfaces::msg::JobFinished>(
-                "job_finished", 10,
+                topic_names::JobFinished, 10,
                 [common_node, test_node,
                  &executor](interfaces::msg::JobFinished::ConstSharedPtr msg) {
                     RCLCPP_DEBUG(test_node->get_logger(),


### PR DESCRIPTION
This is the first implementation of explicitly setting the rosout QoS.
I am sure there will be plenty of debate around what QoS settings to use. Think of them as placeholders.
We could also consider moving the constructor implementation into the cpp file.
This way a change in the implementation only means rebuilding the library and not all the other cpp files that include the header as well.
This is also of interest for the telemetry team @maf0115 & @di-math please submit your feedback.